### PR TITLE
Support setting binary string timezones

### DIFF
--- a/src/qdate.erl
+++ b/src/qdate.erl
@@ -343,9 +343,14 @@ date_tz_to_tz(Date, FromTZ, ToTZ) ->
     ActualToTZ = ensure_timezone(ToTZ), 
     localtime:local_to_local(Date,FromTZ,ActualToTZ).
 
+set_timezone(TZ) when is_binary(TZ) ->
+    set_timezone(binary_to_list(TZ));
 set_timezone(TZ) ->
     qdate_srv:set_timezone(TZ).
 
+
+set_timezone(Key,TZ) when is_binary(TZ) ->
+    set_timezone(Key, binary_to_list(TZ));
 set_timezone(Key,TZ) ->
     qdate_srv:set_timezone(Key, TZ).
 
@@ -447,7 +452,7 @@ floor(N) when N < 0 ->
 
 %% emulates as if a forum-type website has a Site tz, and a user-specified tz
 -define(SITE_TZ,"PST").
--define(USER_TZ,"CST").
+-define(USER_TZ,<<"CST">>).
 -define(SELF_TZ,"EST"). %% Self will be the pid of the current running process
 -define(SITE_KEY,test_site_key).
 -define(USER_KEY,test_user_key).
@@ -486,9 +491,11 @@ test_deterministic_parser(_) ->
 
 tz_tests(_) ->
     {inorder,[
+        ?_assertEqual(ok,set_timezone(<<"Europe/Moscow">>)),
+        ?_assertEqual("Europe/Moscow", get_timezone()),
         ?_assertEqual(ok,set_timezone(?SELF_TZ)),
         ?_assertEqual(?SELF_TZ,get_timezone()),
-        ?_assertEqual(?USER_TZ,get_timezone(?USER_KEY)),
+        ?_assertEqual("CST",get_timezone(?USER_KEY)),
         ?_assertEqual(?SITE_TZ,get_timezone(?SITE_KEY)),
         ?_assertEqual({{2013,3,7},{0,0,0}}, to_date(?USER_KEY,"3/7/2013 1:00am EST")),
         ?_assertEqual({{2013,3,7},{0,0,0}}, to_date(?SITE_KEY,"3/7/2013 3:00am EST")),


### PR DESCRIPTION
I noticed that setting a timezone value to a binary string made bad things happen under the hood of qdate.

```
15> qdate:set_timezone(<<"America/New York">>).            
(<0.52.0>) call qdate:set_timezone(<<"America/New York">>)
(<0.52.0>) returned from qdate:set_timezone/1 -> ok
ok
16> qdate:to_unixtime({{2013,9,18},{9,0,0}}).  
(<0.52.0>) call qdate:to_unixtime({{2013,9,18},{9,0,0}})
(<0.52.0>) call qdate:to_date("GMT",{{2013,9,18},{9,0,0}})
(<0.52.0>) call qdate:extract_timezone({{2013,9,18},{9,0,0}})
(<0.52.0>) call qdate:determine_timezone()
(<0.52.0>) returned from qdate:determine_timezone/0 -> <<"America/New York">>
(<0.52.0>) returned from qdate:extract_timezone/1 -> {{{2013,9,18},{9,0,0}},
                                                      <<"America/New York">>}
(<0.52.0>) call qdate:try_registered_parsers({{2013,9,18},{9,0,0}})
(<0.52.0>) call qdate:try_parsers({{2013,9,18},{9,0,0}},[])
(<0.52.0>) returned from qdate:try_parsers/2 -> undefined
(<0.52.0>) returned from qdate:try_registered_parsers/1 -> undefined
(<0.52.0>) call qdate:raw_to_date({{2013,9,18},{9,0,0}})
(<0.52.0>) returned from qdate:raw_to_date/1 -> {{2013,9,18},{9,0,0}}
** exception error: no function clause matching 
                    calendar:date_to_gregorian_days(error)
     in function  calendar:datetime_to_gregorian_seconds/1
     in call from qdate:to_unixtime/1
(<0.52.0>) call qdate:date_tz_to_tz({{2013,9,18},{9,0,0}},<<"America/New York">>,"GMT")
(<0.52.0>) call qdate:ensure_timezone("GMT")
17> (<0.52.0>) returned from qdate:ensure_timezone/1 -> "GMT"
(<0.52.0>) returned from qdate:date_tz_to_tz/3 -> {error,unknown_tz}
(<0.52.0>) returned from qdate:to_date/2 -> {error,unknown_tz}
```

There are obviously a lot of different ways to fix this, but here is one.

All of the unit tests pass after this change.

Thanks.
