### PR TITLE
Support character escaping

### DIFF
--- a/src/qdate.erl
+++ b/src/qdate.erl
@@ -125,6 +125,8 @@ to_string(Format, ToTZ, Disambiguate, Date) when is_list(Format) ->
 
 to_string_worker([], _, _, _) ->
     "";
+to_string_worker([$\\,H|RestFormat], ToTZ, Disamb, Date) ->
+    [H|to_string_worker(RestFormat, ToTZ, Disamb, Date)];
 to_string_worker([$e|RestFormat], ToTZ, Disamb, Date) ->
     ToTZ ++ to_string_worker(RestFormat, ToTZ, Disamb, Date);
 to_string_worker([$I|RestFormat], ToTZ, Disamb, Date) ->


### PR DESCRIPTION
Currently there is no way to print a literal format character, because [qdate:to_string_worker/4](https://github.com/choptastic/qdate/blob/master/src/qdate.erl#L126) aggressively parses them before [ec_date:format/3](https://github.com/erlware/erlware_commons/blob/master/src/ec_date.erl#L408) can escape them.

``` erlang-repl
1> qdate:to_string("Y").
"2014"
2> qdate:to_string("\\Y").
"\\2014"
```

This patch will do a same thing as `ec_date`, escaping format character with `\\`.

``` erlang-repl
1> qdate:to_string("Y").
"2014"
2> qdate:to_string("\\Y").
"Y"
3> qdate:to_string("Z").
"+0"
4> qdate:to_string("\\Z").
"Z"
```
