### PR TITLE
added missing applications to app.src

### DIFF
--- a/src/qdate.app.src
+++ b/src/qdate.app.src
@@ -5,6 +5,8 @@
   {registered, []},
   {applications, [
                   kernel,
+                  erlang_localtime,
+                  erlware_commons,
                   stdlib
                  ]},
   {modules, [qdate, qdate_srv]},


### PR DESCRIPTION
the app.src file was missing the `erlang_localtime` and `erlware_commons` applications, this causes relx or other applications that traverse the application dependencies graph to miss those two.