### PR TITLE
Move to rebar3 and hex package

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,22 +2,8 @@
 %% vim:ts=4 sw=4 et ft=erlang
 {cover_enabled, true}.
 
-%% For rebar2 compat
 {deps,
  [
-  %% This uses an older erlware_commons version so retain compatibility with
-  %% rebar2. v0.16.1 introduced a 'cf' dependency, which seems to cause
-  %% breakage.
-  {erlware_commons,  ".*", {git, "git://github.com/erlware/erlware_commons.git",     {tag, "v0.15.0"}}},
-
-  {erlang_localtime, ".*", {git, "git://github.com/choptastic/erlang_localtime.git", {branch, master}}}
+  {erlware_commons,  "0.18.0"},
+  {erlang_localtime, "1.0.0"}
  ]}.
-
-%% for rebar3
-{profiles,
- [{pkg,
-   [{deps,
-     [
-      erlware_commons,
-      erlang_localtime
-     ]}]}]}.

--- a/src/qdate.app.src
+++ b/src/qdate.app.src
@@ -11,7 +11,7 @@
                  ]},
   {modules, [qdate, qdate_srv]},
   {env, []},
-  {contributors, ["Jesse Gumm"]},
+  {maintainers, ["Jesse Gumm", "Heinz Gies"]},
   {licenses, ["MIT"]},
   {links, [{"Github", "https://github.com/choptastic/qdate"}]}
  ]}.


### PR DESCRIPTION
Hi I've published jesse as a hex package, this are the changes necessary to make it hex-able with riak3. Since it is your project it would be great if you'd take over the package, for that you can ask hex.pm to change ownership, until then I'll try to keep it up to date with the latest tagged release.

For the meantime I added myself as a secondary maintainer so that people having questions regarding the package don't bother you, please remove that if you take over the package since I don't want to claim your work as mine.

Please not that this moves the build tool fully to rebar3.
