### PR TITLE
Use qdate_localtime in app.src

### DIFF
--- a/src/qdate.app.src
+++ b/src/qdate.app.src
@@ -5,7 +5,7 @@
   {registered, []},
   {applications, [
                   kernel,
-                  erlang_localtime,
+                  qdate_localtime,
                   erlware_commons,
                   stdlib
                  ]},


### PR DESCRIPTION
Fixes a small dependency issue, which appears to me to be a small oversight. This change is needed to allow `application:ensure_all_started/1` to run correctly for applications depending on qdate.