### PR TITLE
[WIP] R19 dialyzer

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,5 +5,5 @@
 {deps,
  [
   {erlware_commons, "~>1.0.0"},
-  qdate_localtime
+  {qdate_localtime, "~>1.1.0"}
  ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -4,6 +4,6 @@
 
 {deps,
  [
-  erlware_commons,
+  {erlware_commons, "~>1.0.0"},
   qdate_localtime
  ]}.

--- a/src/qdate.app.src
+++ b/src/qdate.app.src
@@ -11,7 +11,7 @@
                  ]},
   {modules, [qdate, qdate_srv]},
   {env, []},
-  {contributors, ["Jesse Gumm"]},
+  {maintainers, ["Jesse Gumm"]},
   {licenses, ["MIT"]},
   {links, [{"Github", "https://github.com/choptastic/qdate"}]}
  ]}.

--- a/src/qdate.app.src
+++ b/src/qdate.app.src
@@ -1,7 +1,7 @@
 {application, qdate,
  [
   {description, "Simple Date and Timezone handling for Erlang"},
-  {vsn, "0.4.2"},
+  {vsn, "0.4.4"},
   {registered, []},
   {applications, [
                   kernel,


### PR DESCRIPTION
WIP - please don't merge yet it's not complete

I'm working on getting qdate working and clean with r19 some hex improvements (aka ranged dependencies).

There are a few problems I'm not sure how to resolve, most notably qdate uses `application:set_env` with parameters that violate the function specification and I'm not sure what the 'right' way to resolve this is.


```
  94: The call application:set_env('qdate', {'qdate_var',{'qdate_format',_} | {'qdate_parser',_} | {'qdate_tz',_}}, Val::any()) breaks the contract (Application, Par, Val) -> 'ok' when Application :: atom(), Par :: atom(), Val :: term()
```