### PR TITLE
Stacktrace workaround for compatibility with OTP 21

### DIFF
--- a/src/qdate.erl
+++ b/src/qdate.erl
@@ -131,6 +131,13 @@
     parse/1
 ]).
 
+%% erlang:get_stacktrace/0 is deprecated in OTP 21
+-ifndef(OTP_RELEASE).
+-define(WITH_STACKTRACE(T, R, S), T:R -> S = erlang:get_stacktrace(), ).
+-else.
+-define(WITH_STACKTRACE(T, R, S), T:R:S ->).
+-endif.
+
 %% This the value in gregorian seconds for jan 1st 1970, 12am
 %% It's used to convert to and from unixtime, since unixtime starts 
 %% 1970-01-01 12:00am
@@ -1076,8 +1083,7 @@ try_parsers(RawDate,[{ParserKey,Parser}|Parsers]) ->
         Other ->
             throw({invalid_parser_return_value,[{parser_key,ParserKey},{return,Other}]})
     catch
-        Error:Reason -> 
-            Stacktrace = erlang:get_stacktrace(),
+        ?WITH_STACKTRACE(Error, Reason, Stacktrace)
             throw({error_in_parser,[{error,{Error,Reason}},{parser_key,ParserKey}, {stacktrace, Stacktrace}]})
     end.
 


### PR DESCRIPTION
erlang:stacktrace/0 is deprecated in latest OTP releases so compiling qdate with OTP 21 return the following warning:
```
src/qdate.erl:1080: Warning: erlang:get_stacktrace/0: deprecated; use the new try/catch syntax for retrieving the stack backtrace
```