### PR TITLE
Use actual erlware_commons for rebar 2

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -9,7 +9,7 @@ case erlang:function_exported(rebar3, main, 1) of
         %% Rebuild deps, possibly including those that have been moved to
         %% profiles
         [{deps, [
-            {erlware_commons, "", {git, "git://github.com/erlware/erlware_commons", {tag, "0916834752"}}}, %% this is the version of erlware_commons that works until erlware tags a new version
+            {erlware_commons, "", {git, "git://github.com/erlware/erlware_commons", {tag, "v1.3.1"}}}, %% this is the version of erlware_commons that works until erlware tags a new version
             {qdate_localtime, "", {git, "git://github.com/choptastic/qdate_localtime", {tag, "1.1.0"}}}
         ]} | lists:keydelete(deps, 1, CONFIG)]
 end.


### PR DESCRIPTION
0916834752 is too old and incompatible with latest OTP releases.